### PR TITLE
Spread starting positions (Circular points)

### DIFF
--- a/Code/BotWars2Server.Tests/BotWars2Server.Tests.csproj
+++ b/Code/BotWars2Server.Tests/BotWars2Server.Tests.csproj
@@ -63,6 +63,7 @@
   <ItemGroup>
     <Compile Include="LogicTests\GameManagerTests\CheckForCollisionsTests.cs" />
     <Compile Include="LogicTests\GameManagerTests\IsPositionValidForPlayerTests.cs" />
+    <Compile Include="LogicTests\GameManagerTests\SetStartPositionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestTests.cs" />
   </ItemGroup>

--- a/Code/BotWars2Server.Tests/LogicTests/GameManagerTests/SetStartPositionsTests.cs
+++ b/Code/BotWars2Server.Tests/LogicTests/GameManagerTests/SetStartPositionsTests.cs
@@ -1,0 +1,52 @@
+﻿using BotWars2Server.Code.Logic;
+using BotWars2Server.Code.State;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BotWars2Server.Tests.LogicTests.GameManagerTests
+{
+    public class SetStartPositionsTests
+    {
+        [TestCase(250, 250, 200, 125, 50, 125, TestName = "In a 250*250 arena the two players are played at 200,125 and 50,125")]
+        [TestCase(500, 500, 450, 250, 50, 250, TestName = "In a 500*500 arena the two players are played at 450,250 and 50,250")]
+        [TestCase(250, 500, 450, 125, 50, 125, TestName = "In a 250*500 arena the two players are played at 450,125 and 50,125")]
+        public void TwoPlayers(int arenaX, int arenaY, int p1x, int p1y, int p2x, int p2y)
+        {
+            var arena = CreateArena(arenaX, arenaY);
+            var manager = new GameManager(arena, arena.Players.First(), arena.Players.Last());
+
+            manager.SetStartPositions();
+
+            Assert.AreEqual(new Position(p1x, p1y), arena.Players.First().Position);
+            Assert.AreEqual(new Position(p2x, p2y), arena.Players.Last().Position);
+        }
+
+
+        public Arena CreateArena(int arenaX, int arenaY)
+        {
+            var players = new Player[]
+            {
+                new Mock<Player>(Guid.NewGuid().ToString()).Object,
+                new Mock<Player>(Guid.NewGuid().ToString()).Object
+            };
+
+            var arena = new Arena
+            {
+                Height = arenaX,
+                Width = arenaY,
+                Players = players,
+                Tracks = new Track[]
+                {
+                    new Track(players.First()),
+                    new Track(players.Last())
+                },
+            };
+            return arena;
+        }
+    }
+}

--- a/Code/BotWars2Server/Code/Logic/GameManager.cs
+++ b/Code/BotWars2Server/Code/Logic/GameManager.cs
@@ -29,7 +29,7 @@ namespace BotWars2Server.Code.Logic
                 tracks.Add(new Track(player));
             }
             this.Arena.Tracks = tracks;
-            this.SetStartPositions(50);
+            this.SetStartPositions();
 
             foreach (var player in this.Arena.Players)
             {
@@ -68,10 +68,12 @@ namespace BotWars2Server.Code.Logic
         }
 
         /// <summary>
-        /// Assigns each bot to there start positions by drawing a circle and spreading players evenly around the edges.
+        /// The Size of the Internal Circle.
         /// </summary>
-        private void SetStartPositions(int radius)
+        /// <param name="paddingFromEdge">How close the players will be to the edge</param>
+        private void SetStartPositions(int paddingFromEdge = 50)
         {
+            var radius = (this.Arena.Width - (paddingFromEdge * 2)) / 2;
 
             Position centrepoint = new Position(this.Arena.Width / 2, this.Arena.Height / 2);
             var currentAngle = 0;

--- a/Code/BotWars2Server/Code/Logic/GameManager.cs
+++ b/Code/BotWars2Server/Code/Logic/GameManager.cs
@@ -29,7 +29,7 @@ namespace BotWars2Server.Code.Logic
                 tracks.Add(new Track(player));
             }
             this.Arena.Tracks = tracks;
-            this.SetStartPositions();
+            this.SetStartPositions(50);
 
             foreach (var player in this.Arena.Players)
             {
@@ -68,17 +68,29 @@ namespace BotWars2Server.Code.Logic
         }
 
         /// <summary>
-        /// Assigns each bot to a random start position
+        /// Assigns each bot to there start positions by drawing a circle and spreading players evenly around the edges.
         /// </summary>
-        private void SetStartPositions()
+        private void SetStartPositions(int radius)
         {
-            var random = new Random();
-            foreach(var bot in this.Arena.Players)
+
+            Position centrepoint = new Position(this.Arena.Width / 2, this.Arena.Height / 2);
+            var currentAngle = 0;
+
+            foreach (var player in this.Arena.Players)
             {
-                bot.Position = new Position(
-                    random.Next(10, this.Arena.Width - 10),
-                    random.Next(10, this.Arena.Height - 10));
+                var xcoords = (Math.Round(radius * (Math.Cos(currentAngle * (Math.PI / 180)))));
+                var ycoords = (Math.Round(radius * (Math.Sin(currentAngle * (Math.PI / 180)))));
+                player.Position = new Position((int)xcoords + centrepoint.X, (int)ycoords + centrepoint.Y);
+                currentAngle = currentAngle + 360 / this.Players.Count();
             }
+
+            //var random = new Random();
+            //foreach(var bot in this.Arena.Players)
+            //{
+            //    bot.Position = new Position(
+            //        random.Next(10, this.Arena.Width - 10),
+            //        random.Next(10, this.Arena.Height - 10));
+            //}
         }
 
         /// <summary>

--- a/Code/BotWars2Server/Code/Logic/GameManager.cs
+++ b/Code/BotWars2Server/Code/Logic/GameManager.cs
@@ -83,14 +83,6 @@ namespace BotWars2Server.Code.Logic
                 player.Position = new Position((int)xcoords + centrepoint.X, (int)ycoords + centrepoint.Y);
                 currentAngle = currentAngle + 360 / this.Players.Count();
             }
-
-            //var random = new Random();
-            //foreach(var bot in this.Arena.Players)
-            //{
-            //    bot.Position = new Position(
-            //        random.Next(10, this.Arena.Width - 10),
-            //        random.Next(10, this.Arena.Height - 10));
-            //}
         }
 
         /// <summary>

--- a/Code/BotWars2Server/Code/Logic/GameManager.cs
+++ b/Code/BotWars2Server/Code/Logic/GameManager.cs
@@ -74,7 +74,6 @@ namespace BotWars2Server.Code.Logic
         private void SetStartPositions(int paddingFromEdge = 50)
         {
             var radius = (this.Arena.Width - (paddingFromEdge * 2)) / 2;
-
             Position centrepoint = new Position(this.Arena.Width / 2, this.Arena.Height / 2);
             var currentAngle = 0;
 

--- a/Code/BotWars2Server/Code/Logic/GameManager.cs
+++ b/Code/BotWars2Server/Code/Logic/GameManager.cs
@@ -71,7 +71,7 @@ namespace BotWars2Server.Code.Logic
         /// The Size of the Internal Circle.
         /// </summary>
         /// <param name="paddingFromEdge">How close the players will be to the edge</param>
-        private void SetStartPositions(int paddingFromEdge = 50)
+        public void SetStartPositions(int paddingFromEdge = 50)
         {
             var radius = (this.Arena.Width - (paddingFromEdge * 2)) / 2;
             Position centrepoint = new Position(this.Arena.Width / 2, this.Arena.Height / 2);

--- a/Code/BotWars2Server/Code/State/Position.cs
+++ b/Code/BotWars2Server/Code/State/Position.cs
@@ -24,5 +24,10 @@
         {
             return (this.X * this.Y * 27).GetHashCode();
         }
+
+        public override string ToString()
+        {
+            return string.Concat(this.X, ",", this.Y);
+        }
     }
 }

--- a/Code/BotWars2Server/MainForm.cs
+++ b/Code/BotWars2Server/MainForm.cs
@@ -32,6 +32,12 @@ namespace BotWars2Server
                 Width = 200,
             },
             new RandomBot(),
+            new RandomBot(),
+            new RandomBot(),
+            new RandomBot(),
+            new RandomBot(),
+            new RandomBot(),
+            new RandomBot(),
             new RandomBot());
         }
     }

--- a/Code/BotWars2Server/MainForm.cs
+++ b/Code/BotWars2Server/MainForm.cs
@@ -32,12 +32,6 @@ namespace BotWars2Server
                 Width = 200,
             },
             new RandomBot(),
-            new RandomBot(),
-            new RandomBot(),
-            new RandomBot(),
-            new RandomBot(),
-            new RandomBot(),
-            new RandomBot(),
             new RandomBot());
         }
     }


### PR DESCRIPTION
Spreads out the players in a game by determining coordinates at an edge of a circle at x degrees following on from each other.
For each player x is the 360 / players + the previous players degree.

E.g. for 6 players they will appear on the edge of the circle at x degrees:
0
60
120
180
240
300
